### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/includes/class-wc-iugu-credit-card-gateway.php
+++ b/includes/class-wc-iugu-credit-card-gateway.php
@@ -449,7 +449,7 @@ class WC_Iugu_Credit_Card_Gateway extends WC_Payment_Gateway {
 		}
 	}
 
-	public function process_refund($order_id, $amount = NULL, $reason = '')
+	public function process_refund($order_id, $amount = null, $reason = '')
 	{
 		return $this->api->refund_order($order_id, $amount);
 	}


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!